### PR TITLE
3d tsdf multiple submaps

### DIFF
--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -708,9 +708,6 @@ void MapBuilderBridge::ProcessTSDFMesh(pcl::PolygonMesh &mesh,
   size_t count = 0;
   bool skipped_current_submap = false;
 
-  // TODO remove
-  LOG(INFO) << "iterating " << map_builder_->pose_graph()->GetAllSubmapData().size();
-
   if (!all_submap_data.empty()) {
     for (auto const & submap_data : all_submap_data) {
       if (!all_submaps && all_submap_data.size() > 1 && !skipped_current_submap) {
@@ -783,7 +780,7 @@ void MapBuilderBridge::ProcessTSDFMesh(pcl::PolygonMesh &mesh,
 
       }
     }
-    LOG(INFO) << "Triangles in Cloud: " << cloud.size() / 3;
+    LOG(INFO) << "[TSDF Mesh] Triangles in Cloud: " << cloud.size() / 3;
 
     pcl::toPCLPointCloud2(cloud, mesh.cloud);
 

--- a/cartographer_ros/cartographer_ros/map_builder_bridge.cc
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.cc
@@ -704,6 +704,7 @@ void MapBuilderBridge::ProcessTSDFMesh(pcl::PolygonMesh &mesh,
       ::cartographer::mapping::PoseGraphInterface::SubmapData>
       data = map_builder_->pose_graph()->GetAllSubmapData();
 
+  // TODO allow for multiple submaps
   if (!data.empty()) {
     const auto submap3d =
         static_cast<const ::cartographer::mapping::Submap3D *>(

--- a/cartographer_ros/cartographer_ros/map_builder_bridge.h
+++ b/cartographer_ros/cartographer_ros/map_builder_bridge.h
@@ -163,8 +163,14 @@ class MapBuilderBridge {
    * @param cut_off_height float as cut-off-height above the robots current height. Negative values
    * indicate no cut-off along this dimension
    * @param min_weight minimal weight of TSD value TO BE DISCARDED when iterating the TSDF voxels
+   * @param all_submaps if true, all submaps will be iterated, possible having duplicates. Otherwise
+   * the second last submap will be used except if there is only one
    */
-  void ProcessTSDFMesh(pcl::PolygonMesh &mesh, float cut_off_distance, float cut_off_height, float min_weight);
+  void ProcessTSDFMesh(pcl::PolygonMesh &mesh,
+                       float cut_off_distance,
+                       float cut_off_height,
+                       float min_weight,
+                       bool all_submaps);
 
   /**
    * Uses a visualization_msgs::Marker Triangle_List as representation for the surface mesh


### PR DESCRIPTION
This extension to the 3D TSDF Meshing visualization allows to deal with multiple submaps, as requested by Task #2961: https://redmine.sim.informatik.tu-darmstadt.de/issues/2961
When exporting a mesh to a ply file, all submaps are iterated and all points are treated sequentially, leading to possible superimposed mesh surfaces. In contrast, when using the live debug visualization in Rviz, only the second last submap is used, if available. I only one submap is available, this one will be used.